### PR TITLE
Cancel the kill timer when execution finishes

### DIFF
--- a/lib/rambo.ex
+++ b/lib/rambo.ex
@@ -12,7 +12,7 @@ defmodule Rambo do
           err: String.t()
         }
   @type args :: String.t() | [iodata()] | nil
-  @type result :: {:ok, t()} | {:error, t() | String.t()}
+  @type result :: {:ok, t()} | {:error, t() | String.t()} | {:killed, t()}
 
   alias __MODULE__
 

--- a/lib/rambo.ex
+++ b/lib/rambo.ex
@@ -166,14 +166,16 @@ defmodule Rambo do
         if envs, do: send_envs(port, envs)
         if current_dir, do: send_current_dir(port, current_dir)
 
-        if is_integer(timeout) do
-          Process.send_after(self(), :kill, timeout)
-        end
+        timer_ref =
+          if is_integer(timeout) do
+            Process.send_after(self(), :kill, timeout)
+          end
 
         run_command(port)
 
         port
         |> receive_result(%Rambo{}, log)
+        |> cancel_timer(timer_ref)
         |> output_to_binary()
 
       command ->
@@ -308,5 +310,12 @@ defmodule Rambo do
 
   defp to_binary(output) do
     output
+  end
+
+  defp cancel_timer(result, nil), do: result
+
+  defp cancel_timer(result, timer_ref) do
+    Process.cancel_timer(timer_ref)
+    result
   end
 end


### PR DESCRIPTION
This prevents that the timer will respond later and GenServer's that do not have implemented the `handle_info` will crash. Also the typespec of `result` was missing `{:killed, t()}`.