### PR TITLE
Add support for compilation on apple silicon

### DIFF
--- a/priv/Cargo.lock
+++ b/priv/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "rambo"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "futures",
  "tokio",


### PR DESCRIPTION
- [x] Add `macarm` target and filename
- [x] Test on the M1 iMac
- [x] Test in a mix project
    - It only worked for me when I added `:rambo` to my list of compilers in my project's `mix.exs`. I think this is because it was installed through the `:git` way and not the normal hex way. But I'm not sure what is expected here. I imagine once CI runs and it's published to hex it will work auto-magically.